### PR TITLE
Add support for laravel 5.4. App share was deprecated

### DIFF
--- a/src/Digivo/StringBladeCompiler/StringBladeCompilerServiceProvider.php
+++ b/src/Digivo/StringBladeCompiler/StringBladeCompilerServiceProvider.php
@@ -38,7 +38,7 @@ class StringBladeCompilerServiceProvider extends ServiceProvider
         $config_path = __DIR__ . '/../../../config/string-blade-compiler.php';
         $this->mergeConfigFrom($config_path, 'string-blade-compiler');
 
-        $this->app['stringview'] = $this->app->share(function ($app) {
+        $this->app->singleton('stringview', function ($app) {
             $cache_path = storage_path('app/string-blade-compiler/views');
 
             $string_view = new StringView($app['config']);


### PR DESCRIPTION
Upgrading to Laravel 5.4 breaks current package as the deprecated share() method has been removed.

```php
$this->app['stringview'] = $this->app->share(function ($app) {
            $cache_path = storage_path('app/string-blade-compiler/views');
            $string_view = new StringView($app['config']);
            $compiler = new StringBladeCompiler($app['files'], $cache_path, $app['config'], $app);
            $string_view->setEngine(new CompilerEngine($compiler));
            return $string_view;
});
```
https://laravel.com/docs/5.4/upgrade

From the documentation: The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the singleton method instead:

```php
$container->singleton('foo', function () {
    return 'foo';
});
```

I updated the service provider to reflect those changes. I would like to use your package in a project but I can't for now because the share method does not exist anymore in Laravel 5.4. Can you please merge it soon ?

Thank you for your awesome work!